### PR TITLE
Using semver 1.x

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 91dbd1bbbc43a2e92354007b9dce2bb0cfe1453a314bc881a95393a582e10ffc
-updated: 2015-12-31T11:15:32.790058621-07:00
+hash: 5c2d72233fc025922735df734b32754a29f7d2a5ed494a2b1ea612516e0cbbc1
+updated: 2016-04-11T11:12:28.478505806-04:00
 imports:
 - name: github.com/codegangsta/cli
-  version: c31a7975863e7810c92e2e288a9ab074f9a88f29
+  version: 71f57d300dd6a780ac1856c005c4b518cfd498ec
 - name: github.com/Masterminds/semver
-  version: 6333b7bd29aad1d79898ff568fd90a8aa533ae82
+  version: 808ed7761c233af2de3f9729a041d68c62527f3a
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,5 @@
 package: github.com/technosophos/vert
 import:
 - package: github.com/Masterminds/semver
+  version: ^1.x
 - package: github.com/codegangsta/cli


### PR DESCRIPTION
Since SemVer 2.x is coming with API changes it's worth pinning to a 1.x version.
