### PR TITLE
Updating the exit code to be in range (255 max)

### DIFF
--- a/vert.go
+++ b/vert.go
@@ -162,7 +162,7 @@ func compare(base string, cases []string) ([]*semver.Version, []*semver.Version,
 	constraint, err := semver.NewConstraint(base)
 	if err != nil {
 		perr("Could not parse constraint %s", base)
-		return passed, failed, 256
+		return passed, failed, 128
 	}
 
 	for _, t := range cases {


### PR DESCRIPTION
128 appears to be the most appropriate code.
See http://www.tldp.org/LDP/abs/html/exitcodes.html