### PR TITLE
Corrections to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+vert

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+DESTDIR=/usr/local/bin
+
 all: bootstrap test install
 
 setup:
@@ -7,14 +9,14 @@ bootstrap:
 	dep ensure
 	dep status
 
-build:
+vert:
 	go build -o vert vert.go
 
 test:
 	go test .
 
-install: build
-	install -d ${DESTDIR}/usr/local/bin/
-	install -m 755 ./vert ${DESTDIR}/usr/local/bin/vert
+install: vert
+	install -d ${DESTDIR}
+	install -m 755 ./vert ${DESTDIR}/vert
 
-.PHONY: bootstrap test build install all setup
+.PHONY: bootstrap test install all setup


### PR DESCRIPTION
The targetname for the build should be "vert" since that is the name of
the file produced.

DESTDIR is not being set or used correctly. This commit updates it so it
can be overridden.